### PR TITLE
:sparkles: skill damage calculate change

### DIFF
--- a/Assets/Script/Battle/Player/PlayerAttack.cs
+++ b/Assets/Script/Battle/Player/PlayerAttack.cs
@@ -150,7 +150,7 @@ public class PlayerAttack : MonoBehaviour //플레이어의 입력을 받아서 스킬 커맨드
         
         for (int i = 0; i < currentSkill.damage.Length; i++) { 
         yield return new WaitForSeconds(currentSkill.waitTimes[i]);
-            battlePresenter.PlayerSkillToEnemy(new Damage(currentSkill.damage[i], currentSkill.damageType[i]?new SlashDamage():new PierceDamage()));
+            battlePresenter.PlayerSkillToEnemy(new Damage(currentSkill.damage[i]*playerAttackStat, currentSkill.damageType[i]?new SlashDamage():new PierceDamage()));
         }
 
     }

--- a/Assets/Script/Battle/Player/PlayerSkill.cs
+++ b/Assets/Script/Battle/Player/PlayerSkill.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 public class PlayerSkill : ScriptableObject
 {
     public struct Skill {
-        public int[] damage;
+        public float[] damage;
         public bool[] damageType;
         public AnimationClip skillClip;
         public float[] waitTimes;
@@ -27,8 +27,8 @@ public class PlayerSkill : ScriptableObject
     [Header("PlayerAttack class에서 처리할 데이터들")]
     [Space(1f)]
     [SerializeField] ParticleSystem skillParticle;
-    [Tooltip("배열의 길이는 타수를 의미함 각 타수마다 대미지를 넣을 것")]
-    [SerializeField] private int[] damage; //공격 타수가 배열 길이
+    [Tooltip("배열의 길이는 타수를 의미함 각 타수마다 대미지를 넣을 것 대미지는 기본공격력에 곱해진다.")]
+    [SerializeField] private float[] damage; //공격 타수가 배열 길이
     [Tooltip("각 float은 대미지가 들어가기까지 걸리는 시간을 의미함. 마지막 공격 이후 다음 공격까지 걸리는 시간을 입력")]
     [SerializeField] private float[] waitTimes;
     [Tooltip("각 공격의 대미지 타입을 의미함. (true는 베기공격, false는 찌르기 공격을 의미함.)")]
@@ -38,7 +38,7 @@ public class PlayerSkill : ScriptableObject
     [Tooltip("스킬에 사용되는 애니메이션 클립.")]
     [SerializeField] string soundEventName;
     public string SkillName { get => skillName; }
-    public int[] Damage { get => damage; }
+    public float[] Damage { get => damage; }
     public string[] SkillCommand { get => skillCommand; } // 성재 : string을 사용해서 A,B,R 이렇게 사용하는 게 메모리 측면에서 이득을 볼 수 있을 듯 /재욱: 확인확인
     public ParticleSystem SkillParticle { get => skillParticle;  }
     public Sprite SkillIcon { get => skillIcon; }

--- a/Assets/Script/Battle/Player/Skill/Fuga.asset
+++ b/Assets/Script/Battle/Player/Skill/Fuga.asset
@@ -22,7 +22,9 @@ MonoBehaviour:
   isSpacialSkill: 0
   coolTimeTurn: 2
   skillParticle: {fileID: 3941128118579984434, guid: a58309f6feafd76418f4a1f9570b5e53, type: 3}
-  damage: 0a0000000f000000
+  damage:
+  - 1.4
+  - 1.5
   waitTimes:
   - 1.1
   - 0.6

--- a/Assets/Script/Battle/Player/Skill/Toccata.asset
+++ b/Assets/Script/Battle/Player/Skill/Toccata.asset
@@ -22,7 +22,10 @@ MonoBehaviour:
   isSpacialSkill: 0
   coolTimeTurn: 2
   skillParticle: {fileID: 3494102379653789117, guid: 09c1a4d43c7ccc54887fe51cd1c6671d, type: 3}
-  damage: 040000000400000007000000
+  damage:
+  - 1.3
+  - 1.3
+  - 1.3
   waitTimes:
   - 0.06
   - 0.24


### PR DESCRIPTION
## 변경사항
-  스킬 대미지의 계산방식이 변경됩니다.
    스킬은 기본공격력에 %를 곱해서 대미지를 가합니다.
## 이슈사항
-
## 참고자료 (선택)
