### PR TITLE
:ambulance: hot fix main bgm

### DIFF
--- a/Assets/Resources/UI/Status/PlayerHP.prefab
+++ b/Assets/Resources/UI/Status/PlayerHP.prefab
@@ -148,6 +148,9 @@ GameObject:
   - component: {fileID: -351092242001114219}
   - component: {fileID: 6807115482616471819}
   - component: {fileID: 6482097871774866650}
+  - component: {fileID: -5029446876529818119}
+  - component: {fileID: -1811709240716714960}
+  - component: {fileID: -2512850353123117950}
   m_Layer: 5
   m_Name: PlayerHP
   m_TagString: Untagged
@@ -222,6 +225,45 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   filling: {fileID: 5350755003793852388}
 --- !u!114 &6482097871774866650
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2905799570252644066}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a66d0e9964019c44cb050f59069e3802, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  filling: {fileID: 5350755003793852388}
+--- !u!114 &-5029446876529818119
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2905799570252644066}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a66d0e9964019c44cb050f59069e3802, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  filling: {fileID: 5350755003793852388}
+--- !u!114 &-1811709240716714960
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2905799570252644066}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a66d0e9964019c44cb050f59069e3802, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  filling: {fileID: 5350755003793852388}
+--- !u!114 &-2512850353123117950
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -609,7 +651,7 @@ MonoBehaviour:
   m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 1
-  m_FillAmount: 0.19
+  m_FillAmount: 0
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0

--- a/Assets/Script/General/Menu/MainMenu/NewGame.cs
+++ b/Assets/Script/General/Menu/MainMenu/NewGame.cs
@@ -14,7 +14,7 @@ public class NewGame : Menu
     public override void OnPressed()
     {
         AkSoundEngine.PostEvent("MainMenu_Click_GameStart_SFX", gameObject);
-        AkSoundEngine.PostEvent("MainMenu_BGM_BGM_Stop", gameObject);
+        AkSoundEngine.PostEvent("MainMenu_BGM_BGM_Stop", gameObject.transform.parent.gameObject);
         fadeOut.DOFade(1, 2f).onComplete += () => UnityEngine.SceneManagement.SceneManager.LoadScene("Top View");
     }
 }


### PR DESCRIPTION
## 변경사항
-  메인 bgm을 계속 호출하는 버그 수정
## 이슈사항
- 메인 메뉴에서 bgm을 재생시키고 새 게임 버튼에서 bgm을 멈추려고 해서  정상적으로 멈추지 않고 메인메뉴가 루프마다 bgm을 호출시키는 게 원인 -> 메인메뉴의 오브젝트를 가져와서 멈추게 함
## 참고자료 (선택)
